### PR TITLE
Able to build using catkin_make

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,8 @@ generate_messages()
 
 catkin_package(
   CATKIN_DEPENDS roscpp roslib message_runtime)
-
+  
+include_directories(${catkin_INCLUDE_DIRS})
 add_executable(mp3_inventory src/mp3_inventory.cpp)
 add_executable(mp3_controller src/mp3_controller.cpp)
 


### PR DESCRIPTION
Able to build using catkin_make

include_directories(${catkin_INCLUDE_DIRS})  needs to be added in the CMakeLists.txt

I m a ROS beginner. I downloaded your files but unable to build, so I add this line into the CMakeLists.txt
